### PR TITLE
Update to AVA 0.15.2 and tweak syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "cheerio": "^0.20.0"
   },
   "devDependencies": {
-    "ava": "^0.12.0",
+    "ava": "0.15.2",
     "chokidar-cli": "^1.2.0",
     "coveralls": "^2.11.6",
-    "nyc": "^6.0.0",
-    "xo": "^0.12.1"
+    "nyc": "^7.0.0",
+    "xo": "^0.16"
   },
   "engines": {
     "node": ">= 0.12"

--- a/test/svgstore.js
+++ b/test/svgstore.js
@@ -1,35 +1,35 @@
-import svgstore from '../src/svgstore';
 import test from 'ava';
+import svgstore from '../src/svgstore';
 
-var doctype = '<?xml version="1.0" encoding="UTF-8"?>' +
+const doctype = '<?xml version="1.0" encoding="UTF-8"?>' +
 	'<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" ' +
 	'"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
 
-test('should create an svg document', async assert => {
-	var store = svgstore();
-	var svg = store.toString();
+test('should create an svg document', async t => {
+	const store = svgstore();
+	const svg = store.toString();
 
-	assert.is(svg.slice(0, 5), '<?xml');
+	t.is(svg.slice(0, 5), '<?xml');
 });
 
-test('should create an svg element', async assert => {
-	var store = svgstore();
-	var svg = store.toString({inline: true});
+test('should create an svg element', async t => {
+	const store = svgstore();
+	const svg = store.toString({inline: true});
 
-	assert.is(svg.slice(0, 4), '<svg');
+	t.is(svg.slice(0, 4), '<svg');
 });
 
-test('should combine svgs', async assert => {
-	var store = svgstore()
+test('should combine svgs', async t => {
+	const store = svgstore()
 		.add('foo', doctype + '<svg viewBox="0 0 100 100"><defs><linear-gradient/></defs><path/></svg>')
 		.add('bar', doctype + '<svg viewBox="0 0 200 200"><defs><radial-gradient/></defs><rect/></svg>');
 
-	var expected = doctype +
+	const expected = doctype +
 		'<svg xmlns="http://www.w3.org/2000/svg">' +
 		'<defs><linear-gradient/><radial-gradient/></defs>' +
 		'<symbol id="foo" viewBox="0 0 100 100"><path/></symbol>' +
 		'<symbol id="bar" viewBox="0 0 200 200"><rect/></symbol>' +
 		'</svg>';
 
-	assert.is(store.toString(), expected);
+	t.is(store.toString(), expected);
 });


### PR DESCRIPTION
I’ve been getting started on #2, and when writing out a few tests I noticed that our version of `ava` was missing support for a few [new assertion methods](https://github.com/avajs/ava/releases/tag/v0.14.0) and some [bug fixes](https://github.com/avajs/ava/releases/tag/v0.15.2).

This PR gets us on the latest `ava` and its related packages that we’re using (`xo` and `nyc`), and also makes a few syntax changes to fix the ESLint errors that got caught in the process.

Also, @shannonmoeller, how do you feel about [using `const`/`let` as a opposed to `var`](http://programmers.stackexchange.com/a/274352) in our tests. I can revert that if you have any objections.
