### PR TITLE
Add logic for copying custom attributes; Make core processing functionality more modular

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ See the [examples directory](https://github.com/shannonmoeller/svgstore/tree/mas
 
 Creates a container svg sprites document.
 
+- `options` `{Object}`: [Options for converting SVGs to symbols](#svgstore-options)
+
 ### .element
 
 The current [cheerio](https://github.com/cheeriojs/cheerio) instance.
@@ -60,6 +62,14 @@ Appends a file to the sprite with the given `id`.
   - `inline` `{Boolean}` (default: `false`) Don't output `<?xml ?>` and `DOCTYPE`.
 
 Outputs sprite as a string of XML.
+
+## <a name="svgstore-options"></a>Options
+
+- `customSymbolAttrs` `{Array}` (default: `[]`) Custom attributes to have `svgstore` attempt to copy to the newly created `<symbol/>` tag from the root SVG.
+
+  These will be searched for in addition to `id`, `viewBox`, `aria-labelledby`, and `role`.
+
+
 
 ## Contribute
 

--- a/src/svgstore.js
+++ b/src/svgstore.js
@@ -3,21 +3,20 @@
 var assign = require('object-assign');
 var cheerio = require('cheerio');
 
-var ATTRIBUTE_ID = 'id';
-var ATTRIBUTE_VIEW_BOX = 'viewBox';
+var svgToSymbol = require('./utils/svg-to-symbol');
 
 var SELECTOR_DEFS = 'defs';
 var SELECTOR_SVG = 'svg';
 
 var TEMPLATE_SVG = '<svg xmlns="http://www.w3.org/2000/svg"><defs/></svg>';
-var TEMPLATE_SYMBOL = '<symbol/>';
 var TEMPLATE_DOCTYPE = '<?xml version="1.0" encoding="UTF-8"?>' +
 	'<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" ' +
 	'"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
 
 var DEFAULT_OPTIONS = {
 	cleanDefs: false,
-	cleanObjects: false
+	cleanObjects: false,
+	customSymbolAttrs: []
 };
 
 function load(text) {
@@ -55,34 +54,25 @@ function svgstore(options) {
 		element: parent,
 
 		add: function (id, file, options) {
-			var child = load(file);
 			var childOptions = assign({}, parentOptions, options);
 
-			var childSvg = child(SELECTOR_SVG);
+			var child = load(file);
 			var childDefs = child(SELECTOR_DEFS);
-			var childSymbol = child(TEMPLATE_SYMBOL);
 
 			var cleanDefs = childOptions.cleanDefs;
-			var cleanObjects = childOptions.cleanObjects;
-
-			// clean and merge <defs/>
-
 			if (cleanDefs) {
 				clean(child, childDefs, cleanDefs);
 			}
-
 			parentDefs.append(childDefs.contents());
 			childDefs.remove();
 
-			// clean and clone <svg/> as <symbol/>
+			var childSymbol = svgToSymbol(id, child, childOptions);
 
+			// clean <symbol/>
+			var cleanObjects = childOptions.cleanObjects;
 			if (cleanObjects) {
-				clean(child, childSvg, cleanObjects);
+				clean(child, childSymbol, cleanObjects);
 			}
-
-			childSymbol.attr(ATTRIBUTE_ID, id);
-			childSymbol.attr(ATTRIBUTE_VIEW_BOX, childSvg.attr(ATTRIBUTE_VIEW_BOX));
-			childSymbol.append(childSvg.contents());
 
 			// append <symbol/>
 			parentSvg.append(childSymbol);

--- a/src/utils/svg-to-symbol.js
+++ b/src/utils/svg-to-symbol.js
@@ -1,0 +1,66 @@
+'use strict';
+
+var union = require('./union');
+
+var TEMPLATE_SYMBOL = '<symbol/>';
+
+var SELECTOR_SVG = 'svg';
+
+var ATTRIBUTE_ID = 'id';
+var ATTRIBUTE_VIEWBOX = 'viewBox';
+var ATTRIBUTE_ARIA_LABELLED_BY = 'aria-labelledby';
+var ATTRIBUTE_ROLE = 'role';
+
+var DEFAULT_ATTRS_TO_COPY = [
+	ATTRIBUTE_VIEWBOX,
+	ATTRIBUTE_ARIA_LABELLED_BY,
+	ATTRIBUTE_ROLE
+];
+
+
+/**
+ * Utility for cloning an <svg/> as a <symbol/> within
+ * the composition of svgstore output.
+ *
+ * @param {string} id The id to be applied to the symbol tag
+ * @param {string} loadedChild An object created by loading the content of the current file via the cheerio#load function.
+ * @param {object} options for parsing the svg content
+ * @returns {object} symbol The final cheerio-aware object created by cloning the SVG contents
+ * @see <a href="https://github.com/cheeriojs/cheerio">The Cheerio Project</a>
+ */
+function svgToSymbol(id, loadedChild, options) {
+	var svgElem = loadedChild(SELECTOR_SVG);
+
+	// initialize a new <symbol> element
+	var symbol = loadedChild(TEMPLATE_SYMBOL);
+	symbol.attr(ATTRIBUTE_ID, id);
+
+	copyRootSVGAttributes(options.customSymbolAttrs, symbol, svgElem);
+
+	// Finally, append the contents of the `svgElem` to the symbol
+	symbol.append(svgElem.contents());
+
+	return symbol;
+}
+
+
+/**
+ *  Make sure the symbol carries over the proper attributes on the original `<svg>`
+ */
+function copyRootSVGAttributes(customSymbolAttrs, symbol, originalSVG) {
+	var customAttrs = Array.isArray(customSymbolAttrs) ? customSymbolAttrs : [];
+
+	var attributesToCopy = union(DEFAULT_ATTRS_TO_COPY, customAttrs);
+	var attrName, attrValue;
+	for (var i = 0; i < attributesToCopy.length; i++) {
+		attrName = attributesToCopy[i];
+		attrValue = originalSVG.attr(attrName);
+
+		if (typeof attrValue !== 'undefined' && attrValue !== null) {
+			symbol.attr(attrName, attrValue);
+		}
+	}
+}
+
+
+module.exports = svgToSymbol;

--- a/src/utils/union.js
+++ b/src/utils/union.js
@@ -1,0 +1,21 @@
+/**
+ * Helper for set construction. In future ECMAScript 2015+ syntax,
+ * `Set`s can just be made directly
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set">Set</a>
+ */
+function union(a, b) {
+	var obj = {};
+
+	a.forEach(function (elem) {
+		obj[elem] = elem;
+	});
+	b.forEach(function (elem) {
+		obj[elem] = elem;
+	});
+
+	return Object.keys(obj).map(function (key) {
+		return obj[key];
+	});
+}
+
+module.exports = union;

--- a/test/svgstore.js
+++ b/test/svgstore.js
@@ -5,6 +5,16 @@ const doctype = '<?xml version="1.0" encoding="UTF-8"?>' +
 	'<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" ' +
 	'"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
 
+const FIXTURE_SVGS = {
+	foo: '<svg viewBox="0 0 100 100"><defs><linear-gradient style="fill: red;"/></defs><path style="fill: red;"/></svg>',
+	bar: '<svg viewBox="0 0 200 200"><defs><radial-gradient style="stroke: red;"/></defs><rect style="stroke: red;"/></svg>',
+	baz: '<svg viewBox="0 0 200 200"><defs><linear-gradient style="fill: red;"/></defs><path style="fill: red;"/></svg>',
+	qux: '<svg viewBox="0 0 200 200"><defs><radial-gradient style="stroke: red;" fill="blue"/></defs><rect style="stroke: red;" fill="blue"/></svg>',
+	quux: '<svg viewBox="0 0 200 200" aria-labelledby="titleId" role="img"><title id="titleId">A boxy shape</title><rect/></svg>',
+	corge: '<svg viewBox="0 0 200 200" aria-labelledby="titleId" role="img" preserveAspectRatio="xMinYMax" take-me-too="foo" count-me-out="bar">' +
+		'<title id="titleId">A boxy shape</title><rect/></svg>'
+};
+
 test('should create an svg document', async t => {
 	const store = svgstore();
 	const svg = store.toString();
@@ -21,14 +31,14 @@ test('should create an svg element', async t => {
 
 test('should combine svgs', async t => {
 	const store = svgstore()
-		.add('foo', doctype + '<svg viewBox="0 0 100 100"><defs><linear-gradient/></defs><path/></svg>')
-		.add('bar', doctype + '<svg viewBox="0 0 200 200"><defs><radial-gradient/></defs><rect/></svg>');
+		.add('foo', doctype + FIXTURE_SVGS.foo)
+		.add('bar', doctype + FIXTURE_SVGS.bar);
 
 	const expected = doctype +
 		'<svg xmlns="http://www.w3.org/2000/svg">' +
-		'<defs><linear-gradient/><radial-gradient/></defs>' +
-		'<symbol id="foo" viewBox="0 0 100 100"><path/></symbol>' +
-		'<symbol id="bar" viewBox="0 0 200 200"><rect/></symbol>' +
+		'<defs><linear-gradient style="fill: red;"/><radial-gradient style="stroke: red;"/></defs>' +
+		'<symbol id="foo" viewBox="0 0 100 100"><path style="fill: red;"/></symbol>' +
+		'<symbol id="bar" viewBox="0 0 200 200"><rect style="stroke: red;"/></symbol>' +
 		'</svg>';
 
 	t.is(store.toString(), expected);
@@ -36,12 +46,12 @@ test('should combine svgs', async t => {
 
 test('should clean defs', async t => {
 	const store = svgstore({cleanDefs: true})
-		.add('foo', doctype + '<svg viewBox="0 0 100 100"><defs><linear-gradient style="fill: red;"/></defs><path style="fill: red;"/></svg>')
-		.add('bar', doctype + '<svg viewBox="0 0 200 200"><defs><radial-gradient style="stroke: red;"/></defs><rect style="stroke: red;"/></svg>')
-		.add('baz', doctype + '<svg viewBox="0 0 200 200"><defs><linear-gradient style="fill: red;"/></defs><path style="fill: red;"/></svg>', {
+		.add('foo', doctype + FIXTURE_SVGS.foo)
+		.add('bar', doctype + FIXTURE_SVGS.bar)
+		.add('baz', doctype + FIXTURE_SVGS.baz, {
 			cleanDefs: []
 		})
-		.add('qux', doctype + '<svg viewBox="0 0 200 200"><defs><radial-gradient style="stroke: red;" fill="blue"/></defs><rect style="stroke: red;" fill="blue"/></svg>', {
+		.add('qux', doctype + FIXTURE_SVGS.qux, {
 			cleanDefs: ['fill']
 		});
 
@@ -59,12 +69,12 @@ test('should clean defs', async t => {
 
 test('should clean objects', async t => {
 	const store = svgstore({cleanObjects: true})
-		.add('foo', doctype + '<svg viewBox="0 0 100 100"><defs><linear-gradient style="fill: red;"/></defs><path style="fill: red;"/></svg>')
-		.add('bar', doctype + '<svg viewBox="0 0 200 200"><defs><radial-gradient style="stroke: red;"/></defs><rect style="stroke: red;"/></svg>')
-		.add('baz', doctype + '<svg viewBox="0 0 200 200"><defs><linear-gradient style="fill: red;"/></defs><path style="fill: red;"/></svg>', {
+		.add('foo', doctype + FIXTURE_SVGS.foo)
+		.add('bar', doctype + FIXTURE_SVGS.bar)
+		.add('baz', doctype + FIXTURE_SVGS.baz, {
 			cleanObjects: []
 		})
-		.add('qux', doctype + '<svg viewBox="0 0 200 200"><defs><radial-gradient style="stroke: red;" fill="blue"/></defs><rect style="stroke: red;" fill="blue"/></svg>', {
+		.add('qux', doctype + FIXTURE_SVGS.qux, {
 			cleanObjects: ['fill']
 		});
 
@@ -75,6 +85,35 @@ test('should clean objects', async t => {
 		'<symbol id="bar" viewBox="0 0 200 200"><rect/></symbol>' +
 		'<symbol id="baz" viewBox="0 0 200 200"><path style="fill: red;"/></symbol>' +
 		'<symbol id="qux" viewBox="0 0 200 200"><rect style="stroke: red;"/></symbol>' +
+		'</svg>';
+
+	t.is(store.toString(), expected);
+});
+
+test('should attempt to preserve the `viewBox`, `aria-labelledby`, and `role` attributes of the root SVG by default', async t => {
+	const store = svgstore()
+		.add('quux', FIXTURE_SVGS.quux);
+
+	const expected = doctype +
+		'<svg xmlns="http://www.w3.org/2000/svg">' +
+			'<defs/>' +
+			'<symbol id="quux" viewBox="0 0 200 200" aria-labelledby="titleId" role="img"><title id="titleId">A boxy shape</title><rect/></symbol>' +
+		'</svg>';
+
+	t.is(store.toString(), expected);
+});
+
+test('should support custom attribute preservation, on top of the defaults', async t => {
+	const customSymbolAttrs = ['preserveAspectRatio', 'take-me-too'];
+	const store = svgstore({customSymbolAttrs})
+		.add('corge', FIXTURE_SVGS.corge);
+
+	const expected = doctype +
+		'<svg xmlns="http://www.w3.org/2000/svg">' +
+			'<defs/>' +
+			'<symbol id="corge" viewBox="0 0 200 200" aria-labelledby="titleId" role="img" preserveAspectRatio="xMinYMax" take-me-too="foo">' +
+				'<title id="titleId">A boxy shape</title><rect/>' +
+			'</symbol>' +
 		'</svg>';
 
 	t.is(store.toString(), expected);


### PR DESCRIPTION
This PR implements #4, and also takes a few steps to break out the core svg-to-symbol functionality into its own utility. I'm open to alternative approaches regarding the later change, since originally everything was all implemented in the `add` function, but I think finding a clean way to modularize various concerns will come in handy as we add more features. 
