### PR TITLE
Modify naming of custom attribute API. Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,15 @@ Outputs sprite as a string of XML.
 ## <a name="svgstore-options"></a>Options
 
 - `cleanDefs` `{Boolean|Array}` (default: `false`) Remove `style` attributes from SVG definitions, or a list of attributes to remove.
+
 - `cleanObjects` `{Boolean|Array}` (default: `false`) Remove `style` attributes from SVG objects, or a list of attributes to remove.
-- `customSymbolAttrs` `{Array}` (default: `[]`) Custom attributes to have `svgstore` attempt to copy to the newly created `<symbol/>` tag from the root SVG. These will be searched for in addition to `id`, `viewBox`, `aria-labelledby`, and `role`.
+
+- `customSymbolAttrs` `{Object}` (default: `null`) A mapping of attribute names to values for `svgstore` to set on the final root `<svg>` node.
+
+- `copiedSymbolAttrs` `{Object}` (default: `null`) A list of attributes to have `svgstore` search for in a source `<svg>` 
+    and copy to the newly created `<symbol/>` tag. These will be searched for alongside the following defaults: `id`, `viewBox`, `aria-labelledby`, and `role`.
+    
+- `customSVGAttrs` `{Array}` (default: `null`) Custom attributes to have `svgstore` attempt to copy to the newly created `<symbol/>` tag from the root SVG.
 
 ## Contributing
 

--- a/src/svgstore.js
+++ b/src/svgstore.js
@@ -19,8 +19,9 @@ var DEFAULT_OPTIONS = {
 	cleanDefs: false,
 	cleanSymbols: false,
 	inline: false,
-	svgAttrs: false,
-	symbolAttrs: false
+	customSVGAttrs: null,
+	customSymbolAttrs: null,
+	copiedSymbolAttrs: []
 };
 
 function svgstore(options) {
@@ -46,10 +47,10 @@ function svgstore(options) {
 			childDefs.remove();
 
 			// <symbol>
-			var childSymbol = svgToSymbol(id, child, addOptions);
+			var childSymbol = svgToSymbol(id, child, addOptions.copiedSymbolAttrs);
 
 			removeAttributes(childSymbol, addOptions.cleanSymbols);
-			setAttributes(childSymbol, addOptions.symbolAttrs);
+			setAttributes(childSymbol, addOptions.customSymbolAttrs);
 			parentSvg.append(childSymbol);
 
 			return this;
@@ -63,7 +64,7 @@ function svgstore(options) {
 			// <svg>
 			var svg = clone(SELECTOR_SVG);
 
-			setAttributes(svg, toStringOptions.svgAttrs);
+			setAttributes(svg, toStringOptions.customSVGAttrs);
 
 			// output inline
 			if (toStringOptions.inline) {

--- a/src/utils/set-attributes.js
+++ b/src/utils/set-attributes.js
@@ -5,13 +5,13 @@
 
 'use strict';
 
-function setAttributes(el, attrs) {
-	if (!attrs || typeof attrs !== 'object') {
+function setAttributes(el, attrHash) {
+	if (!attrHash || typeof attrHash !== 'object') {
 		return el;
 	}
 
-	Object.keys(attrs).forEach(function (attr) {
-		var value = attrs[attr];
+	Object.keys(attrHash).forEach(function (attr) {
+		var value = attrHash[attr];
 
 		// Handle function values directly as cherrio passes an unhelpful index
 		// as the first argument in the native function handler.

--- a/src/utils/svg-to-symbol.js
+++ b/src/utils/svg-to-symbol.js
@@ -2,37 +2,30 @@
  * Utility for cloning an <svg/> as a <symbol/> within
  * the composition of svgstore output.
  */
-
 'use strict';
 
 var union = require('./union');
 
-var TEMPLATE_SYMBOL = '<symbol/>';
+var DEFAULT_ATTRS_TO_COPY = [
+  'viewBox',
+  'aria-labelledby',
+  'role'
+];
 
+var TEMPLATE_SYMBOL = '<symbol/>';
 var SELECTOR_SVG = 'svg';
 
-var ATTRIBUTE_ID = 'id';
-var ATTRIBUTE_VIEWBOX = 'viewBox';
-var ATTRIBUTE_ARIA_LABELLED_BY = 'aria-labelledby';
-var ATTRIBUTE_ROLE = 'role';
-
-var DEFAULT_ATTRS_TO_COPY = [
-	ATTRIBUTE_VIEWBOX,
-	ATTRIBUTE_ARIA_LABELLED_BY,
-	ATTRIBUTE_ROLE
-];
 
 /**
  *  Make sure the symbol carries over the proper attributes on the original `<svg>`
  */
-function copyRootSVGAttributes(customSymbolAttrs, symbol, originalSVG) {
+function copySymbolAttributes(customSymbolAttrs, symbol, originalSVG) {
 	var customAttrs = Array.isArray(customSymbolAttrs) ? customSymbolAttrs : [];
-
 	var attributesToCopy = union(DEFAULT_ATTRS_TO_COPY, customAttrs);
-	var attrName, attrValue;
+	
 	for (var i = 0; i < attributesToCopy.length; i++) {
-		attrName = attributesToCopy[i];
-		attrValue = originalSVG.attr(attrName);
+		var attrName = attributesToCopy[i];
+		var attrValue = originalSVG.attr(attrName);
 
 		if (typeof attrValue !== 'undefined' && attrValue !== null) {
 			symbol.attr(attrName, attrValue);
@@ -47,14 +40,14 @@ function copyRootSVGAttributes(customSymbolAttrs, symbol, originalSVG) {
  * @return {object} symbol The final cheerio-aware object created by cloning the SVG contents
  * @see <a href="https://github.com/cheeriojs/cheerio">The Cheerio Project</a>
  */
-function svgToSymbol(id, loadedChild, options) {
+function svgToSymbol(id, loadedChild, symbolAttrsToCopy) {
 	var svgElem = loadedChild(SELECTOR_SVG);
 
 	// initialize a new <symbol> element
 	var symbol = loadedChild(TEMPLATE_SYMBOL);
-	symbol.attr(ATTRIBUTE_ID, id);
+	symbol.attr('id', id);
 
-	copyRootSVGAttributes(options.customSymbolAttrs, symbol, svgElem);
+	copySymbolAttributes(symbolAttrsToCopy, symbol, svgElem);
 
 	// Finally, append the contents of the `svgElem` to the symbol
 	symbol.append(svgElem.contents());

--- a/test/svgstore.js
+++ b/test/svgstore.js
@@ -120,9 +120,9 @@ test('should attempt to preserve the `viewBox`, `aria-labelledby`, and `role` at
 	t.is(store.toString(), expected);
 });
 
-test('should support custom attribute preservation, on top of the defaults', async t => {
-	const customSymbolAttrs = ['preserveAspectRatio', 'take-me-too'];
-	const store = svgstore({customSymbolAttrs})
+test('should support custom attribute copying, on top of the defaults', async t => {
+	const copiedSymbolAttrs = ['preserveAspectRatio', 'take-me-too'];
+	const store = svgstore({copiedSymbolAttrs})
 		.add('corge', FIXTURE_SVGS.corge);
 
 	const expected = doctype +
@@ -136,10 +136,10 @@ test('should support custom attribute preservation, on top of the defaults', asy
 	t.is(store.toString(), expected);
 });
 
-test('should set symbol attributes', async t => {
+test('should support custom attributes on a <symbol>', async t => {
 	const options = {
 		inline: true,
-		symbolAttrs: {
+		customSymbolAttrs: {
 			viewBox: null,
 			id: function (id) {
 				return 'icon-' + id;
@@ -163,12 +163,13 @@ test('should set symbol attributes', async t => {
 	t.is(store.toString(), expected);
 });
 
-test('should set svg attributes', async t => {
+test('should support custom attributes on the root <svg>', async t => {
 	const options = {
 		inline: true,
-		svgAttrs: {
+		customSVGAttrs: {
 			id: 'spritesheet',
-			style: 'display: none'
+			style: 'display: none',
+			custom: 'awesome'
 		}
 	};
 
@@ -176,7 +177,7 @@ test('should set svg attributes', async t => {
 		.add('foo', doctype + FIXTURE_SVGS.foo)
 		.add('bar', doctype + FIXTURE_SVGS.bar);
 
-	const expected = '<svg id="spritesheet" style="display: none">' +
+	const expected = '<svg id="spritesheet" style="display: none" custom="awesome">' +
 		'<defs>' +
 		'<linear-gradient style="fill: red;"/>' +
 		'<radial-gradient style="stroke: red;"/>' +


### PR DESCRIPTION
cc @shannonmoeller 

This PR is a follow-up to #13, and I wanted to propose it before we make the jump to 2.0.

Currently, the difference between copying an existing attribute and writing brand new ones feels a bit a vaguely expressed by our API, so I changed the interface to [the properties `customSVGAttrs`, `customSymbolAttrs`, and `copiedSymbolAttrs`](https://github.com/svgstore/svgstore/compare/master...BrianSipple:polish-attribute-config-for-2.0?expand=1#diff-eb2351e0f250da970d64ded8494e512bR22).

I also filled in a few gaps to the documentation that provide a description for each property. 

_Side note_: After resolving these changes, I'd like to go ahead and cut a new release. There's an out-standing [issue in `broccoli-svgstore`]() that the configurability improvements we've implemented would solve perfectly 😄. 
