### PR TITLE
Readme: Note that `xmlns` is being removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Appends a file to the sprite with the given `id`.
 ### .toString([options]): String
 
 - `options` `{Object}`
-  - `inline` `{Boolean}` (default: `false`) Don't output `<?xml ?>` and `DOCTYPE`.
+  - `inline` `{Boolean}` (default: `false`) Don't output `<?xml ?>`, `DOCTYPE` and the `xmlns` attribute.
 
 Outputs sprite as a string of XML.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Appends a file to the sprite with the given `id`.
 ### .toString([options]): String
 
 - `options` `{Object}`
-  - `inline` `{Boolean}` (default: `false`) Don't output `<?xml ?>`, `DOCTYPE` and the `xmlns` attribute.
+  - `inline` `{Boolean}` (default: `false`) Don't output `<?xml ?>`, `DOCTYPE`, and the `xmlns` attribute.
 
 Outputs sprite as a string of XML.
 


### PR DESCRIPTION
This came in https://github.com/svgstore/svgstore/commit/1d6a41705c0e465823d43d9adbce972400ea4216.