### PR TITLE
Save svgstore as a dev depencency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Combines multiple SVG files into one using `<symbol>` elements which you may [`<
 
 ## Install
 
-    $ npm install --save svgstore
+    $ npm install svgstore --save-dev
 
 ## Usage
 


### PR DESCRIPTION
Like `gulp-svgstore` and `grunt-svgstore`, svgstore should be installed as a dev dependency.