### PR TITLE
feat: add `fragmentIdentifier` option

### DIFF
--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -10,7 +10,7 @@
 			padding: 12%;
 			text-align: center;
 		}
-		svg {
+		svg, img {
 			display: inline-block;
 			height: 12em;
 			width: 12em;
@@ -30,6 +30,9 @@
 
 	<svg role="img"><use xlink:href="./sprites.svg#unicorn" /></svg>
 	<svg role="img"><use xlink:href="./sprites.svg#rainbow" /></svg>
+	<br>
+	<img src="./sprites.svg#view-unicorn">
+	<img src="./sprites.svg#view-rainbow">
 
 	<p><small>Icons by <a href="http://emojione.com/">Emoji One</a></small></p>
 

--- a/docs/examples/make.js
+++ b/docs/examples/make.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var svgstore = require('../src/svgstore');
+var svgstore = require('../../src/svgstore');
 var fs = require('fs');
 
-var sprites = svgstore()
+var sprites = svgstore({ fragmentIdentifier: (id) => `view-${id}` })
 	.add('unicorn', fs.readFileSync('./assets/unicorn.svg', 'utf8'))
 	.add('rainbow', fs.readFileSync('./assets/rainbow.svg', 'utf8'));
 

--- a/docs/examples/sprites.svg
+++ b/docs/examples/sprites.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg"><defs/><symbol id="unicorn" viewBox="0 0 64 64">
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs/><symbol id="unicorn" viewBox="0 0 64 64">
 <g>
 	<g>
 		<g>
@@ -70,7 +70,7 @@
 		c0,0-4.606,5.271-10.041,9.45c0,0,11.297-2.86,18.275-9.357c0,0,0.815,4.672-8.524,7.768C27.792,22.966,54.687,22.269,45.73,9.555z
 		"/>
 </g>
-</symbol><symbol id="rainbow" viewBox="0 0 64 64">
+</symbol><view id="view-unicorn" viewBox="0 0 64 64"/><use xlink:href="#unicorn" width="64" height="64" x="0" y="0"/><symbol id="rainbow" viewBox="0 0 64 64">
 <g>
 	<g>
 		<path fill="#FF6666" d="M62,6.503V2C35.034,2,13.172,23.776,13.172,50.638h4.521C17.692,26.264,37.532,6.503,62,6.503z"/>
@@ -102,4 +102,4 @@
 			c-0.14-0.08-0.281-0.156-0.425-0.229c0-0.022,0-0.044,0-0.066C37.575,38.442,32.79,33.684,26.907,33.684L26.907,33.684z"/>
 	</g>
 </g>
-</symbol></svg>
+</symbol><view id="view-rainbow" viewBox="0 64 64 64"/><use xlink:href="#rainbow" width="64" height="64" x="0" y="64"/></svg>

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "license": "MIT",
   "main": "src/svgstore.js",
   "dependencies": {
+    "@resvg/resvg-js": "^2.1.0",
     "cheerio": "v1.0.0-rc.10"
   },
   "engines": {

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ Outputs sprite as a string of XML.
 - `symbolAttrs` `{Boolean|Object}` (default: `false`) A map of attributes to set on each `<symbol>` element. If you set an attribute's value to null, you remove that attribute. Values may be functions like jQuery.
 - `copyAttrs` `{Boolean|Array}` (default: `false`) Attributes to have `svgstore` attempt to copy to the newly created `<symbol>` tag from it's source `<svg>` tag. The `viewBox`, `aria-labelledby`, and `role` attributes are always copied.
 - `renameDefs` `{Boolean}` (default: `false`) Rename `defs` content ids to make them inherit files' names so that it would help to avoid defs with same ids in the output file.
+- `fragmentIdentifier` `{Function}` (default: `null`) Enable [SVG Fragment Identifiers](https://css-tricks.com/svg-fragment-identifiers-work/) to allow the use of `<img src="icons.svg#unicorn-view" />`. You can custom fragment ID like `(id) => 'view-' + id`
 
 ## Contributing
 

--- a/src/utils/get-svg-rect.js
+++ b/src/utils/get-svg-rect.js
@@ -1,0 +1,11 @@
+const { Resvg } = require('@resvg/resvg-js');
+
+function getSvgRect(svg) {
+  const { width, height } = new Resvg(svg, {
+    logLevel: 'error',
+    font: { loadSystemFonts: false },
+  });
+  return { width, height };
+}
+
+module.exports = getSvgRect;

--- a/test/svgstore.js
+++ b/test/svgstore.js
@@ -230,3 +230,26 @@ test('should rename defs id', async (t) => {
 
 	t.strictEqual(store.toString(), expected);
 });
+
+test('should add <view/> and <use/> to enable SVG Fragment Identifiers', async (t) => {
+	const store = svgstore({ fragmentIdentifier: (id) => `view-${id}` })
+		.add('foo', doctype + FIXTURE_SVGS.foo.replace('<svg', svgNs.slice(0, -1)))
+		.add('bar', doctype + FIXTURE_SVGS.bar.replace('<svg', svgNs.slice(0, -1)));
+
+	const expected =
+		doctype +
+		svgNs +
+		'<defs>' +
+		'<linear-gradient style="fill: red;"/>' +
+		'<radial-gradient style="stroke: red;"/>' +
+		'</defs>' +
+		'<symbol id="foo" viewBox="0 0 100 100"><path style="fill: red;"/></symbol>' +
+		'<view id="view-foo" viewBox="0 0 100 100"/>' +
+		'<use xlink:href="#foo" width="100" height="100" x="0" y="0"/>' +
+		'<symbol id="bar" viewBox="0 0 200 200"><rect style="stroke: red;"/></symbol>' +
+		'<view id="view-bar" viewBox="0 100 200 200"/>' +
+		'<use xlink:href="#bar" width="200" height="200" x="0" y="100"/>' +
+		'</svg>';
+
+	t.strictEqual(store.toString(), expected);
+});


### PR DESCRIPTION
This PR implements #24

SVG file may lack of `width`, `height`, `viewBox` attributes, it's hard to get width and height from SVG file without render it, so I introduce [@resvg/resvg-js](https://github.com/yisibl/resvg-js) library to calc them.

For now SVG Fragment Identifiers feature is opt-in, `<symbol>` is still work, so `id` of `<view>` should not be same with `<symbol>`, it requires a custom function to get `<view>`'s `id`. Another way is treat SVG Fragment Identifiers as another mode which don't set `id` to `<symbol>`, only `<view>` works. I'm not sure which it better, what do you think?

I'm not a native English speaker, edits in REAME may not precise, feel free to edit it.